### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/file.mbt
+++ b/src/file.mbt
@@ -1,7 +1,6 @@
 ///|
 priv struct File {
   name : String
-  platform : String
   path : Array[String]
   path_split : String
   // ext : Array[String]
@@ -28,7 +27,6 @@ fn File::new(
   }
   {
     name: filename,
-    platform: plt,
     path: if filepath[0] == "" {
       match plt {
         "win32" => ["Path"]
@@ -112,18 +110,4 @@ fn File::find_in(self : File) -> Array[String] raise WhichError {
     }
   }
   result
-}
-
-///|
-/// check if the file is executable
-fn File::check_executable(self : File) -> Bool {
-  ...
-}
-
-///|
-/// if file's platform is win32 and the filename doesn't contain a dot(use for ext)  
-/// 
-/// then read the PATHEXT to get the possible ext and return the ext array
-fn File::switch_ext(self : File) -> Array[String] {
-  ...
 }

--- a/src/file.mbt
+++ b/src/file.mbt
@@ -17,7 +17,7 @@ priv struct File {
 /// TODO(or use PATHEXT to get the possible ext)
 fn File::new(
   filename : String,
-  filepath~ : Array[String] = [""]
+  filepath~ : Array[String] = [""],
 ) -> File raise WhichError {
   let plt = get_platform_ffi()
   if plt == "unknown" || plt.has_prefix("Which") {
@@ -80,7 +80,7 @@ fn File::find(self : File) -> Array[String] raise WhichError {
       /// check if the file exists, true then add to the result
       try @fs.is_file(pth) catch {
         _ => continue
-      } else {
+      } noraise {
         _ => result.push(pth)
       }
     }
@@ -107,7 +107,7 @@ fn File::find_in(self : File) -> Array[String] raise WhichError {
     /// check if the file exists, true then add to the result
     try @fs.is_file(pth) catch {
       _ => raise FileNotFound("no such file or directory")
-    } else {
+    } noraise {
       _ => result.push(pth)
     }
   }

--- a/src/which.mbt
+++ b/src/which.mbt
@@ -10,7 +10,7 @@
 pub fn which(filename : String) -> String raise WhichError {
   try which_all(filename) catch {
     e => raise e
-  } else {
+  } noraise {
     v => v[0]
   }
 }
@@ -19,7 +19,7 @@ pub fn which(filename : String) -> String raise WhichError {
 pub fn which_all(filename : String) -> Array[String] raise WhichError {
   try File::new(filename).find() catch {
     e => raise e
-  } else {
+  } noraise {
     v =>
       if v.length() == 0 {
         raise FileNotFound("No such file or directory")
@@ -42,11 +42,11 @@ pub fn which_all(filename : String) -> Array[String] raise WhichError {
 /// - `String` : the absolute path of the file  
 pub fn which_in(
   filename : String,
-  filepath : Array[String]
+  filepath : Array[String],
 ) -> String raise WhichError {
   try which_in_all(filename, filepath) catch {
     e => raise e
-  } else {
+  } noraise {
     v => v[0]
   }
 }
@@ -64,11 +64,11 @@ pub fn which_in(
 /// - `Array[String]` : A string array containing all the file in given filepath  
 pub fn which_in_all(
   filename : String,
-  filepath : Array[String]
+  filepath : Array[String],
 ) -> Array[String] raise WhichError {
   try File::new(filename, filepath~).find_in() catch {
     e => raise e
-  } else {
+  } noraise {
     v =>
       if v.length() == 0 {
         raise FileNotFound("No such file or directory")

--- a/src/which.mbti
+++ b/src/which.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "FrenchPicnic/which"
 
 // Values
@@ -9,7 +10,7 @@ fn which_in(String, Array[String]) -> String raise WhichError
 
 fn which_in_all(String, Array[String]) -> Array[String] raise WhichError
 
-// Types and methods
+// Errors
 pub suberror WhichError {
   PathNotFound(String)
   UnknownPlatform(String)
@@ -17,6 +18,8 @@ pub suberror WhichError {
   FileNotFound(String)
 }
 impl Show for WhichError
+
+// Types and methods
 
 // Type aliases
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit addresses all compiler warnings in the repository:

1. Removed unused 'platform' field from File struct - the platform information is still used locally in File::new function but doesn't need to be stored in the struct since it's never accessed after initialization
2. Removed unused functions 'check_executable' and 'switch_ext' that contained unfinished code (...) and were never called
3. Removed unused variables associated with these functions

All functionality has been preserved while eliminating the warnings. The code now compiles cleanly without any warnings.

Previous commits:
- style: update code format
- style: update interface files